### PR TITLE
fix(deps): remove abort controller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "@adobe/helix-mediahandler",
-  "version": "2.4.18",
+  "version": "2.4.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-mediahandler",
-      "version": "2.4.18",
+      "version": "2.4.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.2",
-        "@aws-sdk/abort-controller": "3.374.0",
         "@aws-sdk/client-s3": "3.552.0",
         "@aws-sdk/lib-storage": "3.552.0",
         "fetch-retry": "6.0.0",
@@ -210,42 +209,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.374.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.374.0.tgz",
-      "integrity": "sha512-pO1pqFBdIF28ZvnJmg58Erj35RLzXsTrjvHghdc/xgtSvodFFCNrUsPg6AP3On8eiw9elpHoS4P8jMx1pHDXEw==",
-      "deprecated": "This package has moved to @smithy/abort-controller",
-      "dependencies": {
-        "@smithy/abort-controller": "^1.0.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/abort-controller/node_modules/@smithy/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
-      "dependencies": {
-        "@smithy/types": "^1.2.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/abort-controller/node_modules/@smithy/types": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
-      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.552.0",
@@ -12187,34 +12150,6 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/abort-controller": {
-      "version": "3.374.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.374.0.tgz",
-      "integrity": "sha512-pO1pqFBdIF28ZvnJmg58Erj35RLzXsTrjvHghdc/xgtSvodFFCNrUsPg6AP3On8eiw9elpHoS4P8jMx1pHDXEw==",
-      "requires": {
-        "@smithy/abort-controller": "^1.0.1",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@smithy/abort-controller": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
-          "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
-          "requires": {
-            "@smithy/types": "^1.2.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
-          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "homepage": "https://github.com/adobe/helix-mediahandler#readme",
   "dependencies": {
     "@adobe/fetch": "4.1.2",
-    "@aws-sdk/abort-controller": "3.374.0",
     "@aws-sdk/client-s3": "3.552.0",
     "@aws-sdk/lib-storage": "3.552.0",
     "fetch-retry": "6.0.0",


### PR DESCRIPTION
I went back in history: already version 1.0.0 had a reference `"@aws-sdk/abort-controller": "3.46.0"`, but I fail to see why