### PR TITLE
fix: include image/webp in accept header

### DIFF
--- a/src/MediaHandler.js
+++ b/src/MediaHandler.js
@@ -357,7 +357,7 @@ export default class MediaHandler {
       headers: {
         range: 'bytes=0-8192',
         'accept-encoding': 'identity',
-        accept: 'image/jpeg,image/jpg,image/png,image/gif,video/mp4,application/xml,image/x-icon,*/*;q=0.8',
+        accept: 'image/jpeg,image/jpg,image/png,image/gif,video/mp4,application/xml,image/x-icon,image/webp,*/*;q=0.8',
       },
       cache: 'no-store',
       signal: timeoutSignal(this._fetchTimeout),

--- a/test/mediahandler.test.js
+++ b/test/mediahandler.test.js
@@ -1269,7 +1269,7 @@ describe('MediaHandler', () => {
     });
     nock('https://www.example.com')
       .get('/test_small_image.png')
-      .matchHeader('accept', 'image/jpeg,image/jpg,image/png,image/gif,video/mp4,application/xml,image/x-icon,*/*;q=0.8')
+      .matchHeader('accept', 'image/jpeg,image/jpg,image/png,image/gif,video/mp4,application/xml,image/x-icon,image/webp,*/*;q=0.8')
       .reply(200);
     await handler.fetchHeader('https://www.example.com/test_small_image.png');
   });


### PR DESCRIPTION
Some images from commerce will not come back with transparency without `image/webp` in the accept header.

https://qual-it.ecom.wilson.com/en-us/media/catalog/product/article_images/WRS328690_/WRS328690__bc9c47e667d37b5bdd81eed1a9f717d4.png