### PR TITLE
fix: send 'accept' header on spool as well

### DIFF
--- a/src/MediaHandler.js
+++ b/src/MediaHandler.js
@@ -718,6 +718,7 @@ export default class MediaHandler {
         // azure does not support transfer encoding:
         // HTTP Error 501. The request transfer encoding type is not supported.
         'accept-encoding': 'identity',
+        accept: 'image/jpeg,image/jpg,image/png,image/gif,video/mp4,application/xml,image/x-icon,image/avif,image/webp,*/*;q=0.8',
       },
     };
     const auth = this._auth(new URL(blob.originalUri));

--- a/test/mediahandler.test.js
+++ b/test/mediahandler.test.js
@@ -144,10 +144,15 @@ describe('MediaHandler', () => {
         'content-length': 8192,
       })
       .get('/test_image.png')
-      .reply(200, testImage, {
-        'content-length': testImage.length,
-        'content-type': 'image/png',
-        'last-modified': '01-01-2021',
+      // eslint-disable-next-line prefer-arrow-callback
+      .reply(function cb() {
+        assert.strictEqual(this.req.headers.accept, 'image/jpeg,image/jpg,image/png,image/gif,video/mp4,application/xml,image/x-icon,image/avif,image/webp,*/*;q=0.8');
+        assert.strictEqual(this.req.headers['accept-encoding'], 'identity');
+        return [200, testImage, {
+          'content-length': testImage.length,
+          'content-type': 'image/png',
+          'last-modified': '01-01-2021',
+        }];
       });
 
     nock('https://helix-media-bus.s3.us-east-1.amazonaws.com')


### PR DESCRIPTION
related to https://github.com/adobe/helix-mediahandler/pull/271